### PR TITLE
comparator should return number not boolean

### DIFF
--- a/modules/list.js
+++ b/modules/list.js
@@ -9,7 +9,7 @@ export default function () {
 
 			const sorted = list
 				.filter(point => point.object <= targetDate)
-				.sort((a ,b) => a.object < b.object);
+				.sort((a, b) => a.object < b.object ? 1 : (a.object > b.object ? -1 : 0));
 			if (sorted.length > 0) {
 				const versions = sorted[0].json.filter(point => point.lastModified <= targetISO);
 				return versions[versions.length - 1] || defaultValue;


### PR DESCRIPTION
Array.prototype.sort accepts a function (comparator) that should return a number not boolean, see https://tc39.github.io/ecma262/#sec-array.prototype.sort